### PR TITLE
docs: flow classify - support arming inspection after flow establishment

### DIFF
--- a/docs/FlowClassifyHook.md
+++ b/docs/FlowClassifyHook.md
@@ -60,7 +60,10 @@ inspects payload segments in order and reaches an allow/block decision about the
 
 Phase 1 (normative):
 
-- A way to choose, per flow, whether to classify that flow's transport payload.
+- A way to choose, per flow, whether to classify that flow's transport payload, at
+  flow establishment or at any later point in the flow's lifetime.
+- A way to stop classifying a flow and later resume, without losing its per-flow
+  state.
 - A hook that receives each transport payload segment in order, for both ingress
   and egress, for flows selected for classification.
   - Three synchronous actions:
@@ -755,6 +758,11 @@ Connect-time redirect of flows.
 
 ## Open Questions
 
+- **Arming after establishment (P1).** Inspection is armed only at flow
+  establishment, and `ALLOW` is the only way to stop inspecting, so inspection
+  cannot be paused and later resumed over the life of a flow. Should P1 support
+  arming and disarming after establishment, and is that an extension of
+  [Re-authorization (P3)](#re-authorization-p3) or a separate mechanism?
 - **Re-authorization data-less re-invoke (P3).** In addition to the re-arm /
   data-driven model, should re-authorization support a **data-less re-invoke**? If
   so, is it a flow classify re-invoke, or a `sock_ops` (or similar) re-invoke that

--- a/docs/FlowClassifyHook.md
+++ b/docs/FlowClassifyHook.md
@@ -66,10 +66,12 @@ Phase 1 (normative):
   state.
 - A hook that receives each transport payload segment in order, for both ingress
   and egress, for flows selected for classification.
-  - Three synchronous actions:
+  - Four synchronous actions:
     - **Allow** the flow and stop inspecting it (for the returning program).
     - **Block** the flow (no further inspection for the returning program).
     - **Need more data**: allow the current segment but keep inspecting.
+    - **Suspend**: allow the current segment and stop inspecting without
+      deciding (keeps per-flow state).
 - A way to clean up per-flow state when a flow is deleted while still being
   classified.
 - No eBPF program is invoked for segments of flows not selected for
@@ -217,6 +219,7 @@ typedef enum _ebpf_flow_classify_metadata_flag
 typedef enum _ebpf_flow_state
 {
     EBPF_FLOW_STATE_CLASSIFYING, ///< Under classification.
+    EBPF_FLOW_STATE_SUSPENDED,   ///< Tracked, not inspecting; resumable.
     EBPF_FLOW_STATE_PENDED,      ///< Awaiting an asynchronous decision (P2).
     EBPF_FLOW_STATE_ALLOWED,     ///< Allowed by this classifier.
     EBPF_FLOW_STATE_BLOCKED,     ///< Blocked (terminal).
@@ -411,6 +414,8 @@ typedef enum _ebpf_flow_classify_action
     EBPF_FLOW_CLASSIFY_ALLOW,          ///< Allow the flow; stop inspecting (this classifier).
     EBPF_FLOW_CLASSIFY_BLOCK,          ///< Block the flow (terminal).
     EBPF_FLOW_CLASSIFY_NEED_MORE_DATA, ///< Allow current segment; keep inspecting.
+    EBPF_FLOW_CLASSIFY_SUSPEND,        ///< Stop inspecting without deciding; resumable.
+    EBPF_FLOW_CLASSIFY_RESUME,         ///< Resume a suspended flow (asynchronous only).
     EBPF_FLOW_CLASSIFY_PEND,           ///< Defer to an asynchronous decision (P2).
     EBPF_FLOW_CLASSIFY_REINVOKE,       ///< Re-run classification (P2 completion).
     EBPF_FLOW_CLASSIFY_REDIRECT,       ///< Redirect (reserved; P4).
@@ -420,8 +425,8 @@ typedef enum _ebpf_flow_classify_action
 Production channels:
 
 - **Inline (synchronous):** a flow classify program returns `ALLOW`, `BLOCK`,
-  `NEED_MORE_DATA`, or (in P2) `PEND`. This is the fast path; it does not require a
-  map write.
+  `NEED_MORE_DATA`, `SUSPEND`, or (in P2) `PEND`. This is the fast path; it does not
+  require a map write.
 - **Asynchronous / user-mode:** a decision is written into the entry's `action`
   field (for example a pending flow's completion, or a re-authorization). The same
   action semantics and the same WFP application path apply, regardless of source.
@@ -443,13 +448,47 @@ the maps tracking a flow:
 
 - `BLOCK` from any classifier is terminal for the flow.
 - `ALLOW` finalizes that map's entry; other maps continue classifying.
+- `SUSPEND` leaves that map's entry in place, in `EBPF_FLOW_STATE_SUSPENDED`.
 - The flow is fully allowed (inspection disarmed) only when **all** tracking maps
   have allowed it.
+- Inspection is armed while **any** tracking map holds the flow in
+  `EBPF_FLOW_STATE_CLASSIFYING`, or in P2 `EBPF_FLOW_STATE_PENDED`.
+- A classifier is invoked only for its own map's entry, and only while that entry
+  is `EBPF_FLOW_STATE_CLASSIFYING`.
 
 This is a deliberate divergence from Linux, which errors if a socket is placed in
 more than one program-bearing map. Allowing multiple maps per flow lets
 independent solutions (for example a security agent and an observability agent)
 classify the same flow without conflict.
+
+#### Suspend / resume and post-establishment arming
+
+Stop and restart inspection of a live flow. Addresses
+[Arming after establishment](#open-questions).
+
+- **Suspend.** `SUSPEND` moves the entry to `EBPF_FLOW_STATE_SUSPENDED`. The entry
+  and its per-flow state remain and the classifier is not invoked. If no other
+  tracking map keeps the flow armed, inspection is disarmed as on `ALLOW`.
+  Available on both channels.
+- **Resume.** `RESUME` returns a `SUSPENDED` entry to `CLASSIFYING` and re-arms
+  inspection. Asynchronous only, since no program runs for a suspended flow.
+- **Arming an untracked flow.** Suspend and resume do not reach a flow that was
+  never tracked, since no program runs for it. Enrollment is re-invoked instead,
+  through a `sock_ops` callback (`BPF_SOCK_OPS_FLOW_REEVALUATE_CB`) issued outside
+  any classify, so the enrollment decision and the `bpf_flow_map_track()` call
+  stay in the program. Scope and trigger mirror
+  [Re-authorization (P3)](#re-authorization-p3), bounded and rate limited.
+- **Re-evaluate context.** Direction is carried today by the establishment op, so
+  the re-evaluate op carries the original direction alongside it. The callback is
+  opt-in, so existing `sock_ops` programs are not invoked with an unknown op.
+- **Resumption contract.** A classifier's per-flow state is valid only for the
+  data it saw. Segments are delivered in order while armed, so a suspension or a
+  late arming leaves a gap the classifier must be told about. How it is signalled
+  is open: a flag distinguishing continuous arming from late or resumed arming is
+  the minimum, and since WFP reports `missedBytes` even while a callout is
+  associated, a per-direction byte offset may be needed instead.
+- `[VERIFY]` Associating a WFP flow context from outside a callout invocation for
+  that flow.
 
 ### Helpers
 
@@ -762,7 +801,8 @@ Connect-time redirect of flows.
   establishment, and `ALLOW` is the only way to stop inspecting, so inspection
   cannot be paused and later resumed over the life of a flow. Should P1 support
   arming and disarming after establishment, and is that an extension of
-  [Re-authorization (P3)](#re-authorization-p3) or a separate mechanism?
+  [Re-authorization (P3)](#re-authorization-p3) or a separate mechanism? See
+  [Suspend / resume](#suspend--resume-and-post-establishment-arming).
 - **Re-authorization data-less re-invoke (P3).** In addition to the re-arm /
   data-driven model, should re-authorization support a **data-less re-invoke**? If
   so, is it a flow classify re-invoke, or a `sock_ops` (or similar) re-invoke that


### PR DESCRIPTION
**PR meant for illustration purposes only - don't merge**

**The gap:**

- Arming happens only at establishment.
- `ALLOW` is the only way to stop inspecting, so inspection cannot be paused and resumed.
- Nothing reaches a flow that was never tracked.

**Added:**

- A new requirement to choose whether to classify a flow at establishment or any later point, and
  stop then resume without losing per-flow state.
- `EBPF_FLOW_STATE_SUSPENDED`, and `SUSPEND` / `RESUME` on the existing action channel.
- `BPF_SOCK_OPS_FLOW_REEVALUATE_CB`, re-invoking enrollment for an established flow, so arming
  stays a program decision.
- The arming invariant as an aggregate over tracking maps, separate from the per-map condition for
  invoking a classifier.
- A resumption contract: per-flow state is valid only for the data the classifier saw.

**Why not `PEND`:**

- Pend withholds the current data; suspend must not.
- Pend is bounded by the watchdog and the quota; a long suspend is the expected case.
- Nothing can be pended on a flow that was never tracked.

**Why this is cheap:**

- netebpfext already invokes a program outside a classify.
- It already manipulates WFP flow contexts out of band.
- `[VERIFY]`: association from outside a callout for that flow

**Open issues:**
1. How should suspend and resume order against flow deletion, and against a classify already in
   flight?
2. Should an action write carry an expected flow id? Keys are reusable, so a late `RESUME` could
   land on a different flow.